### PR TITLE
Implemented ESRGAN and GFPGAN upscaling

### DIFF
--- a/esrgan_onnx.py
+++ b/esrgan_onnx.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+class ESRGAN:
+    def __init__(self, session):
+        self.session = session
+        self.model_input = self.session.get_inputs()[0].name
+
+    def _pre_process(self, image_array):
+        image_array = image_array.transpose(2, 0, 1).astype('float32') / 255.0
+        image_array = np.expand_dims(image_array, axis=0)
+        return image_array
+
+    def _post_process(self, result):
+        result = np.clip(result.transpose(1, 2, 0), 0, 1) * 255.0
+        return result.astype(np.uint8)
+
+    def get(self, image_array):
+        input_size = image_array.shape[1]
+        image_array = self._pre_process(image_array)
+        ort_inputs = {self.model_input: image_array}
+        result = self.session.run(None, ort_inputs)[0][0]
+        result = self._post_process(result)
+        scale_factor = int(result.shape[1] / input_size)
+        return result, scale_factor

--- a/gfpgan_onnx.py
+++ b/gfpgan_onnx.py
@@ -1,0 +1,31 @@
+import cv2
+import numpy as np
+
+class GFPGAN:
+    def __init__(self, session):
+        self.session = session
+        self.model_input = self.session.get_inputs()[0].name
+
+    def _pre_process(self, image_array):
+        image_array = cv2.resize(image_array, (512, 512))
+        image_array = cv2.cvtColor(image_array, cv2.COLOR_BGR2RGB)
+        image_array = image_array.astype('float32') / 255.0
+        image_array = (image_array - 0.5) / 0.5
+        image_array = np.expand_dims(image_array, axis=0).transpose(0, 3, 1, 2)
+        return image_array
+
+    def _post_process(self, result):
+        result = np.clip(result, -1, 1)
+        result = (result + 1) / 2
+        result = result.transpose(1, 2, 0) * 255.0
+        result = cv2.cvtColor(result, cv2.COLOR_RGB2BGR)
+        return result.astype(np.uint8)
+
+    def get(self, image_array):
+        input_size = image_array.shape[1]
+        image_array = self._pre_process(image_array)
+        ort_inputs = {self.model_input: image_array}
+        result = self.session.run(None, ort_inputs)[0][0]
+        result = self._post_process(result)
+        scale_factor = int(result.shape[1] / input_size)
+        return result, scale_factor

--- a/refacer.py
+++ b/refacer.py
@@ -203,10 +203,10 @@ class Refacer:
         if len(faces) != 0:
             if not self.upscale_en: 
                 #print('\nRun native paste_back')
-                frame = self.face_swapper.get(frame, face, self.replacement_faces[0][1], paste_back=True)
+                frame = self.face_swapper.get(frame, faces[0], self.replacement_faces[0][1], paste_back=True)
             else: 
                 #print('\nRun upscale')
-                bgr_fake, M = self.face_swapper.get(frame, face, self.replacement_faces[0][1], paste_back=False)
+                bgr_fake, M = self.face_swapper.get(frame, faces[0], self.replacement_faces[0][1], paste_back=False)
                 frame = self.paste_upscale(bgr_fake,M,frame)
         return frame
 
@@ -218,10 +218,10 @@ class Refacer:
                 if sim>=rep_face[2]:
                     if not self.upscale_en: 
                         #print('\nRun native paste_back')
-                        frame = self.face_swapper.get(frame, face, rep_face[1], paste_back=True)
+                        frame = self.face_swapper.get(frame, faces[i], rep_face[1], paste_back=True)
                     else: 
                         #print('\nRun upscale')
-                        bgr_fake, M = self.face_swapper.get(frame, face, rep_face[1], paste_back=False)
+                        bgr_fake, M = self.face_swapper.get(frame, faces[i], rep_face[1], paste_back=False)
                         frame = self.paste_upscale(bgr_fake,M,frame)
                     del faces[i]
                     break

--- a/upscaler_models/Put ESRGAN and GFPGAN ONNX models here.txt
+++ b/upscaler_models/Put ESRGAN and GFPGAN ONNX models here.txt
@@ -1,0 +1,2 @@
+ESRGAN models can have any filename
+GFPGAN models should be named GFPGAN***


### PR DESCRIPTION
# Face upscaling implementation

## app.py
Added an interface block that lists *.onnx files in the **upscaler_models** folder with radio buttons and a way to pass **upscaler** string to refacer.

## refacer.py
**reface** function is modified so it creates a ESRGAN or GFPGAN objects if the **upscaler** string has corresponding values and makes **self.upscale_en = True**.
**process_faces** functions' code is modified so we can use face_swapper.get(frame, ... , paste_back=False) returning both extracted processed face and M affine matrix for scalar transform, that is then passed to the new **paste_upscale**.
**paste_upscale** function code is from INSwapper, heavily modified to remove unused code and fix jagged edge borders when the faces are partially on the edge of the frame.

## gfpgan_onnx.py 
Added a GFPGAN implementation based on [xuanandsix's GFPGAN-onnxruntime-demo](https://github.com/xuanandsix/GFPGAN-onnxruntime-demo).

You can easily convert the models with the provided scripts. Converted [GFPGANv1.4 model](https://github.com/fAIseh00d/GFPGAN-onnxruntime-demo/releases/download/GFPGANv1.4.onnx/GFPGANv1.4.onnx) provides best identity compared to 1.3 and 1.2, which is crucial for such a small 128px face.

## esrgan_onnx.py
Added a ESRGAN implementation based on my fork of [Sg4Dylan's ESRGAN-ONNX](https://github.com/fAIseh00d/ESRGAN-ONNX).

In my tests the best quality and speed-wise model is converted [2x_DigitalFlim_SuperUltraCompact_nf24-nc8_289k_net_g](https://github.com/fAIseh00d/ESRGAN-ONNX/releases/download/v0.1.0-alpha/2x_DigitalFlim_SuperUltraCompact_nf24-nc8_289k_net_g.onnx), the original found in [Model Database](https://upscale.wiki/wiki/Model_Database).
With that model the performance is almost the same as without upscaling.

It works with regular and compact ESRGAN models, it might even work with RealESRGAN, I haven't tested it.

## how to use
Place downloaded *.onnx weights into **upscaler_models** folder, make sure GFPGAN models contain GFPGAN in the filename. Select model in the radio buttons interface block, **None** uses native INSwapper paste_back processing without upscale.

`WARNING: big model weights warmup at first frames, so refacer kind of hangs for a moment. Then it works fine until you change models/restart.`

## notes
Tested on Windows with CPU/CUDA.

Keep in mind that only 128px face is upscaled, not the whole picture.

Both implementations are as simple as they get, they just convert a int8 numpy.array image to float32 tensor and process it (with 2 different normalizations).

ESRGAN-ONNX repo has a license conflict with Apache 2.0 and MIT being kind of incompatible, so the code in the PR written from scratch.

Personally I recommend using chaiNNer to convert ESRGAN models to *.onnx but it can be done with the code just using torch.
fp16 conversion don't have any performance advantages, at least on CUDA.

## PS
Face masking still works so-so, big area around the face depending on an angle looks worse than the face itself and the rest of the image. I tried MODnet, but it has poor temporal consistency and sometimes misses face parts between frames. 

**_If anyone can recommend any other matting/masking NN's that can be run on ONNX, I'll be grateful!_**