### PR TITLE
a hack to for onnxruntime to use cuda

### DIFF
--- a/recognition/arcface_onnx.py
+++ b/recognition/arcface_onnx.py
@@ -6,6 +6,7 @@
 
 import numpy as np
 import cv2
+import torch
 import onnx
 import onnxruntime
 import face_align

--- a/recognition/arcface_onnx.py
+++ b/recognition/arcface_onnx.py
@@ -6,7 +6,7 @@
 
 import numpy as np
 import cv2
-import torch
+import torch # hack to use onnxruntime with cuda
 import onnx
 import onnxruntime
 import face_align

--- a/recognition/main.py
+++ b/recognition/main.py
@@ -5,7 +5,7 @@ import os.path as osp
 import argparse
 import cv2
 import numpy as np
-import torch
+import torch # hack to use onnxruntime with cuda
 import onnxruntime
 from scrfd import SCRFD
 from arcface_onnx import ArcFaceONNX

--- a/recognition/main.py
+++ b/recognition/main.py
@@ -5,6 +5,7 @@ import os.path as osp
 import argparse
 import cv2
 import numpy as np
+import torch
 import onnxruntime
 from scrfd import SCRFD
 from arcface_onnx import ArcFaceONNX

--- a/recognition/scrfd.py
+++ b/recognition/scrfd.py
@@ -2,7 +2,7 @@
 from __future__ import division
 import datetime
 import numpy as np
-import torch
+import torch # hack to use onnxruntime with cuda
 import onnxruntime
 import os
 import os.path as osp

--- a/recognition/scrfd.py
+++ b/recognition/scrfd.py
@@ -2,7 +2,7 @@
 from __future__ import division
 import datetime
 import numpy as np
-#import onnx
+import torch
 import onnxruntime
 import os
 import os.path as osp

--- a/refacer.py
+++ b/refacer.py
@@ -1,11 +1,11 @@
 import cv2
+import torch
 import onnxruntime as rt
 import sys
 from insightface.app import FaceAnalysis
 sys.path.insert(1, './recognition')
 from scrfd import SCRFD
 from arcface_onnx import ArcFaceONNX
-import os.path as osp
 import os
 from pathlib import Path
 from tqdm import tqdm

--- a/refacer.py
+++ b/refacer.py
@@ -1,5 +1,5 @@
 import cv2
-import torch
+import torch # hack to use onnxruntime with cuda
 import onnxruntime as rt
 import sys
 from insightface.app import FaceAnalysis


### PR DESCRIPTION
`onnxruntime` may not able to use `CUDAExecutionProvider` even if cuda installed

a simple hack is to `import torch` before `import onnxruntime`

u may think im joking but it's explained here: https://github.com/microsoft/onnxruntime/issues/11092#issuecomment-1484756347

u can search for "Failed to create CUDAExecutionProvider" on `onnxruntime` github to verify, people report simply `import torch` helps

this PR may help closing #36 #37 #38 #45 #49